### PR TITLE
Extra comma for some instagram values

### DIFF
--- a/providers/instagram.yml
+++ b/providers/instagram.yml
@@ -3,10 +3,10 @@
   provider_url: https://instagram.com
   endpoints:
   - schemes:
-      - http://instagram.com/*/p/*,
-      - http://www.instagram.com/*/p/*,
-      - https://instagram.com/*/p/*,
-      - https://www.instagram.com/*/p/*,
+      - http://instagram.com/*/p/*
+      - http://www.instagram.com/*/p/*
+      - https://instagram.com/*/p/*
+      - https://www.instagram.com/*/p/*
       - http://instagram.com/p/*
       - http://instagr.am/p/*
       - http://www.instagram.com/p/*


### PR DESCRIPTION
Could it be that there's an extra comma for posts that include the user?